### PR TITLE
docs: Add DOI badge and funding acknowledgments to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# ichep-2022-proceedings
-Source for the pyhf contribution to the proceedings of the ICHEP 2022 conference.
+# pyhf ICHEP 2022 proceedings
+
+Source for the pyhf contribution to the proceedings of the ICHEP 2022 conference published in Proceedings of Science Volume 414 for the talk [pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation](https://agenda.infn.it/event/28874/contributions/169217/).
+
+[![DOI](https://img.shields.io/badge/DOI-10.22323%2F1.414.0245-blue.svg)](https://doi.org/10.22323/1.414.0245)
+
+## Acknowledgments
+
+Matthew Feickert's contributions to this work were supported by the U.S. National Science Foundation (NSF) under Cooperative Agreement [OAC-1836650](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650) (IRIS-HEP).
+Lukas Heinrich is supported by the Excellence Cluster ORIGINS, which is funded by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation) under Germany's Excellence Strategy -- [EXC-2094-390783311](https://www.dfg.de/en/funded_projects/current_projects_programmes/list/projectdetails/index.jsp?id=390783311).


### PR DESCRIPTION
* Link to ICHEP 2022 talk in README.
   - c.f. https://agenda.infn.it/event/28874/contributions/169217/
* Add badge for proceedings DOI to README.
   - c.f. https://doi.org/10.22323/1.414.0245
* Add funding acknowledgments for @matthewfeickert and @lukasheinrich.